### PR TITLE
Adding sane defaults (keep-going and rerun-incomplete) to config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,4 +10,5 @@ max-jobs-per-second: 10
 max-status-checks-per-second: 10
 local-cores: 1
 latency-wait: 120
-
+keep-going: true
+rerun-incomplete: true


### PR DESCRIPTION
Hey @sreichl, at MUW-HPC adding the keep-going field to the config solves the issue that snakemake stops when some job fails

It should have the same effect as when providing the '-k' CLI argument, but for some reason it seems to be different. 

Let me know if this works for you too. Also, did you observe varying behaviour between using a conductor job vs. not?
